### PR TITLE
Adjustment of "brown" theme

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -308,13 +308,13 @@
                     "background": "#13101C",
                     "maxmatch": "#534D6F"
                 },
-                "brown": {
-                    "pasttext": "#E40909B3",
-                    "current": "#C2C2C2",
-                    "next": "#CA861A",
-                    "hover": "#0FD40F",
+                "relish": {
+                    "pasttext": "#9D2117",
+                    "current": "#C8C8C8",
+                    "next": "#C8A032",
+                    "hover": "#E5CB8B",
                     "background": "#121212",
-                    "maxmatch": "#C2C2C2"
+                    "maxmatch": "#787878"
                 }
             }
         },

--- a/patches.json
+++ b/patches.json
@@ -299,6 +299,14 @@
                     "hover": "#D1D1D1",
                     "background": "#13101C",
                     "maxmatch": "#534D6F"
+                },
+                "brown": {
+                    "pasttext": "#E40909B3",
+                    "current": "#C2C2C2",
+                    "next": "#CA861A",
+                    "hover": "#0FD40F",
+                    "background": "#121212",
+                    "maxmatch": "#C2C2C2"
                 }
             }
         },

--- a/patches.json
+++ b/patches.json
@@ -224,7 +224,7 @@
                     "pasttext": "#AD82F8",
                     "current": "#7EE787",
                     "next": "#47566D",
-                    "hover": "##70B3FF",
+                    "hover": "#70B3FF",
                     "background": "#161B22",
                     "maxmatch": "#408BD0"
                 },
@@ -232,7 +232,7 @@
                     "pasttext": "#616774",
                     "current": "#7A8FDC",
                     "next": "#616774",
-                    "hover": "##FFFFFF",
+                    "hover": "#FFFFFF",
                     "background": "#23272A",
                     "maxmatch": "#616774"
                 },
@@ -240,7 +240,7 @@
                     "pasttext": "#505050",
                     "current": "#F37171",
                     "next": "#505050",
-                    "hover": "##A13131",
+                    "hover": "#A13131",
                     "background": "#191414",
                     "maxmatch": "#787878"
                 },
@@ -248,7 +248,7 @@
                     "pasttext": "#505050",
                     "current": "#AEF97B",
                     "next": "#505050",
-                    "hover": "##418022",
+                    "hover": "#418022",
                     "background": "#141914",
                     "maxmatch": "#787878"
                 },
@@ -256,7 +256,7 @@
                     "pasttext": "#505050",
                     "current": "#50DCF0",
                     "next": "#505050",
-                    "hover": "##0B7383",
+                    "hover": "#0B7383",
                     "background": "#14191E",
                     "maxmatch": "#787878"
                 },
@@ -264,7 +264,7 @@
                     "pasttext": "#4E596F",
                     "current": "#F67064",
                     "next": "#4E596F",
-                    "hover": "##FFFFFF",
+                    "hover": "#FFFFFF",
                     "background": "#202430",
                     "maxmatch": "#9EA8BC"
                 },
@@ -272,7 +272,7 @@
                     "pasttext": "#9579E3",
                     "current": "#CD3B99",
                     "next": "#5E547C",
-                    "hover": "##FFFFFF",
+                    "hover": "#FFFFFF",
                     "background": "#1C1925",
                     "maxmatch": "#5E547C"
                 },
@@ -280,7 +280,7 @@
                     "pasttext": "#5C89D2",
                     "current": "#01C38D",
                     "next": "#696E79",
-                    "hover": "##FFFFFF",
+                    "hover": "#FFFFFF",
                     "background": "#191E29",
                     "maxmatch": "#696E79"
                 },
@@ -288,7 +288,7 @@
                     "pasttext": "#1CAAC6",
                     "current": "#90E0F0",
                     "next": "#516377",
-                    "hover": "##A0D1FA",
+                    "hover": "#A0D1FA",
                     "background": "#232937",
                     "maxmatch": "#516377"
                 },
@@ -296,7 +296,7 @@
                     "pasttext": "#C9A8FE",
                     "current": "#9D65C7",
                     "next": "#534D6F",
-                    "hover": "##D1D1D1",
+                    "hover": "#D1D1D1",
                     "background": "#13101C",
                     "maxmatch": "#534D6F"
                 }

--- a/patches.json
+++ b/patches.json
@@ -116,37 +116,189 @@
         },
         "themelyrics": {
             "theme": {
-                "1": {
-                    "pasttext": "#ffffff4a",
-                    "current": "#ffffffc7",
-                    "next": "#ffffff4a",
-                    "hover": "#ffffffc7",
+                "default": {
+                    "pasttext": "#575757",
+                    "current": "#C8C8C8",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
                     "background": "#121212",
-                    "maxmatch": "#ffffff94"
+                    "maxmatch": "#969696"
                 },
-                "2": {
-                    "pasttext": "#ffffffb8",
-                    "current": "#ffffffc7",
-                    "next": "#322319",
-                    "hover": "#ffffffc7",
-                    "background": "#956b4b",
-                    "maxmatch": "#322319"
-                },
-                "3": {
-                    "pasttext": "#ffffff6b",
-                    "current": "#ffffffc7",
-                    "next": "#2e080b",
-                    "hover": "#ffffffc7",
-                    "background": "#c62736f2",
-                    "maxmatch": "#2e080b"
-                },
-                "4": {
-                    "pasttext": "#E40909B3",
-                    "current": "#C2C2C2",
-                    "next": "#CA861A",
-                    "hover": "#0FD40F",
+                "red": {
+                    "pasttext": "#575757",
+                    "current": "#FF3737",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
                     "background": "#121212",
-                    "maxmatch": "#C2C2C2"
+                    "maxmatch": "#969696"
+                },
+                "orange": {
+                    "pasttext": "#575757",
+                    "current": "#F68D00",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
+                    "background": "#121212",
+                    "maxmatch": "#969696"
+                },
+                "yellow": {
+                    "pasttext": "#575757",
+                    "current": "#ECE224",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
+                    "background": "#121212",
+                    "maxmatch": "#969696"
+                },
+                "spotify": {
+                    "pasttext": "#575757",
+                    "current": "#1ED760",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
+                    "background": "#121212",
+                    "maxmatch": "#969696"
+                },
+                "blue": {
+                    "pasttext": "#575757",
+                    "current": "#00DFEA",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
+                    "background": "#121212",
+                    "maxmatch": "#969696"
+                },
+                "purple": {
+                    "pasttext": "#575757",
+                    "current": "#9E6BE3",
+                    "next": "#575757",
+                    "hover": "#C8C8C8",
+                    "background": "#121212",
+                    "maxmatch": "#969696"
+                },
+                "strawberry": {
+                    "pasttext": "#F17F7F",
+                    "current": "#E43A47",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "pumpkin": {
+                    "pasttext": "#FDAC69",
+                    "current": "#E88500",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "sandbar": {
+                    "pasttext": "#FFDB7A",
+                    "current": "#F5BA18",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "radium": {
+                    "pasttext": "#AAFFA3",
+                    "current": "#17D344",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "oceano": {
+                    "pasttext": "#70DBF0",
+                    "current": "#13A1BD",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "royal": {
+                    "pasttext": "#B8A3EB",
+                    "current": "#8461DD",
+                    "next": "#595959",
+                    "hover": "#F2F2F2",
+                    "background": "#1C1C1E",
+                    "maxmatch": "#595959"
+                },
+                "github": {
+                    "pasttext": "#AD82F8",
+                    "current": "#7EE787",
+                    "next": "#47566D",
+                    "hover": "##70B3FF",
+                    "background": "#161B22",
+                    "maxmatch": "#408BD0"
+                },
+                "discord": {
+                    "pasttext": "#616774",
+                    "current": "#7A8FDC",
+                    "next": "#616774",
+                    "hover": "##FFFFFF",
+                    "background": "#23272A",
+                    "maxmatch": "#616774"
+                },
+                "drot": {
+                    "pasttext": "#505050",
+                    "current": "#F37171",
+                    "next": "#505050",
+                    "hover": "##A13131",
+                    "background": "#191414",
+                    "maxmatch": "#787878"
+                },
+                "forest": {
+                    "pasttext": "#505050",
+                    "current": "#AEF97B",
+                    "next": "#505050",
+                    "hover": "##418022",
+                    "background": "#141914",
+                    "maxmatch": "#787878"
+                },
+                "fresh": {
+                    "pasttext": "#505050",
+                    "current": "#50DCF0",
+                    "next": "#505050",
+                    "hover": "##0B7383",
+                    "background": "#14191E",
+                    "maxmatch": "#787878"
+                },
+                "zing": {
+                    "pasttext": "#4E596F",
+                    "current": "#F67064",
+                    "next": "#4E596F",
+                    "hover": "##FFFFFF",
+                    "background": "#202430",
+                    "maxmatch": "#9EA8BC"
+                },
+                "pinkle": {
+                    "pasttext": "#9579E3",
+                    "current": "#CD3B99",
+                    "next": "#5E547C",
+                    "hover": "##FFFFFF",
+                    "background": "#1C1925",
+                    "maxmatch": "#5E547C"
+                },
+                "krux": {
+                    "pasttext": "#5C89D2",
+                    "current": "#01C38D",
+                    "next": "#696E79",
+                    "hover": "##FFFFFF",
+                    "background": "#191E29",
+                    "maxmatch": "#696E79"
+                },
+                "blueberry": {
+                    "pasttext": "#1CAAC6",
+                    "current": "#90E0F0",
+                    "next": "#516377",
+                    "hover": "##A0D1FA",
+                    "background": "#232937",
+                    "maxmatch": "#516377"
+                },
+                "postlight": {
+                    "pasttext": "#C9A8FE",
+                    "current": "#9D65C7",
+                    "next": "#534D6F",
+                    "hover": "##D1D1D1",
+                    "background": "#13101C",
+                    "maxmatch": "#534D6F"
                 }
             }
         },

--- a/patches.json
+++ b/patches.json
@@ -330,16 +330,36 @@
                 "do": ""
             },
             "match": [
+                "(.--lyrics-color-background.:..background)",
                 "(.--lyrics-color-passed.:)(..passed)",
                 "(.--lyrics-color-active.:)((?:.\\?.\\.passed:.|.).active)",
                 "(.--lyrics-color-inactive.:)(..inactive)",
-                "(.--lyrics-color-background.:)(..background)"
+                "(.--lyrics-color-background.:)(..background)",
+                "(.--lyrics-color-hover.:)(\"xxx\")",
+                "(.--lyrics-color-maxmatch.:)(\"xxx\")"
             ],
             "replace": [
+                "$1,\"--lyrics-color-hover\":\"xxx\",\"--lyrics-color-maxmatch\":\"xxx\"",
+                "",
+                "",
                 "",
                 "",
                 "",
                 ""
+            ]
+        },
+        "fixcsslyricscolor2": {
+            "version": {
+                "from": "1.1.99",
+                "do": ""
+            },
+            "match": [
+                "(:hover{color:var)\\(--lyrics-color-active\\)",
+                "(kGR_hu4tdj9PnUlSPaRL{color:var)\\(--lyrics-color-inactive\\)"
+            ],
+            "replace": [
+                "$1(--lyrics-color-hover)!important",
+                "$1(--lyrics-color-maxmatch)!important"
             ]
         },
         "navaltfix": {


### PR DESCRIPTION
Removed alpha component from color of text which was causing render problems in non-latin script lyrics, adjusted overall "brown" theme for best contrast-vibrance balance, renamed "brown" to "relish" (it looks like ketchup and mustard sauce lol)


I have also made this representation of all 24 theme together using mockups (can be used in readme file to showcase the feature):
![picture](https://user-images.githubusercontent.com/86649457/211792881-a1194e52-f658-4558-bbc1-830448ac611f.png)
